### PR TITLE
对死亡事件的重写

### DIFF
--- a/QQBot.sk
+++ b/QQBot.sk
@@ -9,7 +9,7 @@
 # skript-placeholders 1.5
 # AuthMe等登录插件(可选)
 # Maintenance等维护插件(可选)
-# 本脚本的作者是SwallowMC团队的司南(Github:@SinanGentoo)，由司南及开源社区共同维护。如在使用中遇到问题请联系我我发起issue！
+# 本脚本的作者是SwallowMC团队的司南(Github:@SinanGentoo)，由司南及开源社区共同维护。如在使用中遇到问题请联系我或发起issue！
 # =========================
 
 # 一些自定义项
@@ -162,7 +162,7 @@ on bot message:
     {_sub1} start with "reload":
       {@admin} contain qq:
         bot reply "本南狐正在重载~"
-        command "/skript reload QQbot" by console
+        command "/skript reload QQbot.sk" by console
       else if {@silent-mode} is false:
         bot reply "本南狐傲娇到不让你执行命令！"
     {_sub1} start with "backup":

--- a/QQBot.sk
+++ b/QQBot.sk
@@ -26,6 +26,7 @@ import: # 需要引用的java类
   org.bukkit.entity.Player
   org.bukkit.advancement.Advancement
   org.bukkit.event.player.PlayerAdvancementDoneEvent
+  org.bukkit.event.player.PlayerRespawnEvent
   org.bukkit.Server
   fr.xephi.authme.api.v3.AuthMeApi
   
@@ -48,9 +49,21 @@ on bot leave group:
   # 回复群信息
   if group-code is "1043731523":
     bot reply "%sender%(%qq%)离开了群聊"
-  
-on death of player:
-  command "/mcqqbot send group 1043731523 %player's name% 惨叫一声醒在了自己的床上" by console
+
+# on death of player:
+#   command "/mcqqbot send group 1043731523 %player's name% 惨叫一声醒在了自己的床上" by console
+
+# 玩家重生事件
+on PlayerRespawnEvent:
+  set {_isBedSpawn} to event.isBedSpawn()
+  set {_player} to event.getPlayer().getName()
+  if {_isBedSpawn} is true:
+    command "/mcqqbot send group 1043731523 %{_player}% 惨叫一声醒在了自己的床上" by console
+  else:
+    chance of 50%:
+      command "/mcqqbot send group 1043731523 %{_player}% 骂骂咧咧得醒在了主城" by console
+    chance of 50%:
+      command "/mcqqbot send group 1043731523 %{_player}% 迷迷糊糊得醒在了主城" by console
   
 # 当玩家加入时
 on join:


### PR DESCRIPTION
一共有两种情况
1. 玩家重生在了床上，惨叫一声醒在了自己的床上
2. 玩家的床或重生茅不存在或被遮挡，50%的几率骂骂咧咧得醒在了主城，另外50%迷迷糊糊得醒在了主城

已知问题：如果玩家死亡后直接点击标题页面断开连接，可能不会触发该事件